### PR TITLE
LuaInterpret: Handle vector clip tags

### DIFF
--- a/DependencyControl.json
+++ b/DependencyControl.json
@@ -465,14 +465,14 @@
       "description": "Run Lua code on the fly.",
       "channels": {
         "master": {
-          "version": "1.3.0",
-          "released": "2015-05-14",
+          "version": "1.3.1",
+          "released": "2022-11-24",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "85CB97F6616707F87B69866B937F3242465BFFAC"
+              "sha1": "d8da1b6e6c7dfe1575fc6f3fdba9a4aed0d32a35"
             }
           ],
           "requiredModules": [
@@ -489,6 +489,9 @@
         }
       },
       "changelog": {
+        "1.3.1": [
+          "Fix modify not working for vector clips"
+        ],
         "1.3.0": [
           "Added DependencyControl"
         ]

--- a/macros/lyger.LuaInterpret.lua
+++ b/macros/lyger.LuaInterpret.lua
@@ -178,7 +178,7 @@ flags
 
 script_name = "Lua Interpreter"
 script_description = "Run Lua code on the fly."
-script_version = "1.3.0"
+script_version = "1.3.1"
 script_author = "lyger"
 script_namespace = "lyger.LuaInterpret"
 
@@ -537,6 +537,10 @@ function lua_interpret(sub,sel)
 					d=func(c)
 					if tonumber(d) then
 						d = f2s(tonumber(d))
+					end
+					-- if modifying a vector clip, wrap tags in parentheses
+					if b == "clip" or b == "iclip" then
+						c, d = "("..c..")", "("..d..")"
 					end
 				end
 				--Prevent redundancy


### PR DESCRIPTION
When handling a vector clip, the `modify` logic goes into the "single-arg" flow, which doesn't wrap the tag in parentheses. This is correct for e.g. `\fn`, but not `\clip`/`\iclip`. Notably, vector clips with a scale argument (i.e. `\clip(2,m 0 0 ...)`) will get handled correctly by this logic.

This PR fixes the scenario outlined above, and should not affect anything else.