### PR TITLE
GradientEverything: Don't expand against gradient direction with predefined clip

### DIFF
--- a/DependencyControl.json
+++ b/DependencyControl.json
@@ -291,14 +291,14 @@
       "description": "This will gradient everything.",
       "channels": {
         "master": {
-          "version": "2.0.4",
-          "released": "2025-11-09",
+          "version": "2.0.5",
+          "released": "2026-01-11",
           "default": true,
           "files": [
             {
               "name": ".moon",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "4767b4b8e04ab049c79122891ae40f6de68d7a59"
+              "sha1": "a11a5bf704661720b06962d24a64db760d2b0974"
             }
           ],
           "requiredModules": [
@@ -325,6 +325,9 @@
         }
       },
       "changelog": {
+        "2.0.5": [
+          "Prevent expanding clips to video edges if using a \\clip"
+        ],
         "2.0.4": [
           "Now extends clips to video edges."
         ],

--- a/macros/lyger.GradientEverything.moon
+++ b/macros/lyger.GradientEverything.moon
@@ -57,7 +57,7 @@ TODO: Debug, debug, and keep debugging
 
 export script_name = "Gradient Everything"
 export script_description = "This will gradient everything."
-export script_version = "2.0.4"
+export script_version = "2.0.5"
 export script_namespace = "lyger.GradientEverything"
 
 DependencyControl = require "l0.DependencyControl"
@@ -256,6 +256,11 @@ gradient_everything = (sub, sel, res) ->
             logger\warn "Nothing to gradient: The selected lines didn't render to any non-transparent pixels."
             return
 
+        -- Extend bounds to video edges in the non-gradient direction
+        if preset.c.hv_select == "Vertical"
+            bounds[1], bounds[3] = 0, libLyger.meta.res_x
+        else
+            bounds[2], bounds[4] = 0, libLyger.meta.res_y
 
     -- Make sure left is the left and right is the right
     if bounds[1] > bounds[3] then
@@ -267,12 +272,6 @@ gradient_everything = (sub, sel, res) ->
 
     -- The pixel dimension of the relevant direction of gradient
     span = preset.c.hv_select == "Vertical" and bounds[4]-bounds[2] or bounds[3]-bounds[1]
-
-    -- Extend bounds to video edges in the non-gradient direction
-    if preset.c.hv_select == "Vertical"
-        bounds[1], bounds[3] = 0, libLyger.meta.res_x
-    else
-        bounds[2], bounds[4] = 0, libLyger.meta.res_y
 
     --Stores how many frames between each key line
     --Index 1 is how many frames between keys 1 and 2, and so on


### PR DESCRIPTION
Extending the gradient itself to screen edges still should make sense, though.
It's possible both of these should be exposed as options to the user?